### PR TITLE
Support for useManipulate default data config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ useQuery(promise, config) -> [state, action]
 * `defaultData`: any, default null - *data for initial state*
 
 ```javascript
-useManipulate(promise) -> [state, action]
+useManipulate(promise, config) -> [state, action]
 ```
+
+**possible configuration**
+
+* `defaultData`: any, default null - *data for initial state*
 
 ```javascript
 // Check if there are loading in some states
@@ -89,7 +93,7 @@ const ListExample = () => {
   const loading = useLoadingForStates(state, addState, removeState);
 
   const [value, setValue] = useState('');
-  
+
   const handleChange = useCallback((e) => {
     setValue(e.target.value);
   }, [setValue]);

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -12,7 +12,7 @@ import PromiseSwitch from "./PromiseSwitch";
 
 /**
  * Manipulate configuration.
- * @typedef {Object} QueryConfig
+ * @typedef {Object} ManipulateConfig
  * @property {*} [defaultData=null] -The start data for the state.
  */
 
@@ -64,6 +64,7 @@ const usePromise = (promise, updateState, variables, forQuery = false) => {
 /**
  * Manipulation hook to update data.
  * @param {Promise} promise - The promise.
+ * @param {ManipulateConfig} [config={}] - The config to initialize the state.
  * @returns {Array} Array with current state and a manipulate function
  */
 const useManipulate = (promise, config = {defaultData: null}) => {

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -11,6 +11,12 @@ import PromiseSwitch from "./PromiseSwitch";
  */
 
 /**
+ * Manipulate configuration.
+ * @typedef {Object} QueryConfig
+ * @property {*} [defaultData=null] -The start data for the state.
+ */
+
+/**
  * State object.
  * @typedef {Object} State
  * @property {boolean} loading - Loading for promise.
@@ -60,11 +66,11 @@ const usePromise = (promise, updateState, variables, forQuery = false) => {
  * @param {Promise} promise - The promise.
  * @returns {Array} Array with current state and a manipulate function
  */
-const useManipulate = (promise) => {
+const useManipulate = (promise, config = {defaultData: null}) => {
   const [state, updateState] = useState({
     loading: false,
     error: null,
-    data: null,
+    data: config.defaultData,
   });
   const [action, subscriber] = usePromise(promise, updateState);
   useEffect(() => {


### PR DESCRIPTION
There several cases across my project when I must add some OR checks to simulate `useManipulate` `defaultData` config

Example: 
```javascript
const [{data}, someEffect] = useManipulate(() => promise,);
...
<SomeComponent data={data || []} />
```
So idea is to add the same config as `useQuery` has:
```javascript
const [{data}, someEffect] = useManipulate(() => promise, {defaultData: []});
...
<SomeComponent data={data} />
```
